### PR TITLE
Add branch structure note

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,8 @@ mkdocs gh-deploy
 
 Make sure GitHub Pages is enabled in the repo settings → Pages → Source: `gh-pages` branch.
 
+## Branch structure
+
+The `gh-pages` branch is automatically managed by `mkdocs gh-deploy`. It holds only the generated site files and should be treated as read-only. All Markdown documentation resides on the `main` branch. Edit files on `main` and deploy to update `gh-pages`.
+
 ---


### PR DESCRIPTION
## Summary
- explain that `gh-pages` is maintained by MkDocs and is read only
- state that editable documentation lives on the `main` branch

## Testing
- `./test-docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845ad8d520083279285d2aef6471188