### PR TITLE
Fix MkDocs nav for steering docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,9 @@ nav:
       - Camera: hardware/camera/index.md
       - Computer: hardware/computer/index.md
       - Motor: hardware/motor/index.md
-      - Steering Angle Sensor: hardware/steering_angle_sensor/index.md
+      - Steering:
+          - Overview: hardware/steering/index.md
+          - Steering Angle Sensor: hardware/steering/sensor/index.md
       - Emergency Braking System: hardware/ebs/index.md
   - Electronics:
       - Wiring: electronics/wiring.md


### PR DESCRIPTION
## Summary
- fix the path for the steering angle sensor page in `mkdocs.yml`
- add the steering motor page as a sub-entry

## Testing
- `bash test-docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_6858851ca4208327a935839a1ec251ca